### PR TITLE
fix: handle blank text in TextDocumentParser

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/document/TextDocumentParser.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/document/TextDocumentParser.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.document;
 import org.springframework.ai.document.Document;
 import org.springframework.util.Assert;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -42,17 +43,20 @@ public class TextDocumentParser implements DocumentParser {
 	}
 
 	@Override
-	public List<Document> parse(InputStream inputStream) {
-		try {
-			String text = new String(inputStream.readAllBytes(), charset);
-			if (text.isBlank()) {
-				throw new Exception();
-			}
-			return Collections.singletonList(new Document(text));
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
+        public List<Document> parse(InputStream inputStream) {
+                try {
+                        // 读取入口流所有文本，且使用指定的字符集解码
+                        String text = new String(inputStream.readAllBytes(), this.charset);
+                        // 如果文本全部为空白，则报告非法参数异常
+                        if (text.isBlank()) {
+                                throw new IllegalArgumentException("text must not be blank");
+                        }
+                        return Collections.singletonList(new Document(text));
+                }
+                catch (IOException e) {
+                        // 将任何 IO 异常转换为 RuntimeException 以便传播
+                        throw new RuntimeException(e);
+                }
+        }
 
 }

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/document/TextDocumentParserTests.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/document/TextDocumentParserTests.java
@@ -60,27 +60,23 @@ class TextDocumentParserTests {
 		assertThat(documents.get(0).getText()).isEqualTo(text);
 	}
 
-	@Test
-	void testParseEmptyText() {
-		// Test parsing empty text should throw exception
-		String text = "";
-		TextDocumentParser parser = new TextDocumentParser();
+        @Test
+        void testParseEmptyText() {
+                // 空字符串应当触发 IllegalArgumentException
+                String text = "";
+                TextDocumentParser parser = new TextDocumentParser();
 
-		RuntimeException exception = assertThrows(RuntimeException.class, () -> parser.parse(toInputStream(text)));
+                assertThrows(IllegalArgumentException.class, () -> parser.parse(toInputStream(text)));
+        }
 
-		assertThat(exception).hasRootCauseInstanceOf(Exception.class);
-	}
+        @Test
+        void testParseBlankText() {
+                // 含有空格或插入字符的空白字符串同样应抛出 IllegalArgumentException
+                String text = "   \n\t   ";
+                TextDocumentParser parser = new TextDocumentParser();
 
-	@Test
-	void testParseBlankText() {
-		// Test parsing blank text (only whitespace) should throw exception
-		String text = "   \n\t   ";
-		TextDocumentParser parser = new TextDocumentParser();
-
-		RuntimeException exception = assertThrows(RuntimeException.class, () -> parser.parse(toInputStream(text)));
-
-		assertThat(exception).hasRootCauseInstanceOf(Exception.class);
-	}
+                assertThrows(IllegalArgumentException.class, () -> parser.parse(toInputStream(text)));
+        }
 
 	@Test
 	void testConstructorWithNullCharset() {


### PR DESCRIPTION
## Summary
- refine TextDocumentParser to throw IllegalArgumentException on blank input
- update tests to expect IllegalArgumentException

## Testing
- `mvn -pl spring-ai-alibaba-core -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68abc717b580833088c1f642d1ef2634