### PR TITLE
fix: ensure websocket binary send initializes connection

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/protocol/DashScopeWebSocketClient.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/protocol/DashScopeWebSocketClient.java
@@ -101,18 +101,22 @@ public class DashScopeWebSocketClient extends WebSocketListener {
 		}
 	}
 
-	public void sendBinary(ByteBuffer binary) {
-		// TODO
-		// if (!isOpen.get()) {
-		// establishWebSocketClient();
-		// }
+        public void sendBinary(ByteBuffer binary) {
+                if (!isOpen.get()) {
+                        establishWebSocketClient();
+                }
 
-		boolean success = webSocketClient.send(ByteString.of(binary));
+                if (binary == null) {
+                        logger.error("binary data is null");
+                        return;
+                }
 
-		if (!success) {
-			logger.error("send binary failed");
-		}
-	}
+                boolean success = webSocketClient.send(ByteString.of(binary));
+
+                if (!success) {
+                        logger.error("send binary failed");
+                }
+        }
 
 	private void establishWebSocketClient() {
 		HttpLoggingInterceptor logging = new HttpLoggingInterceptor();


### PR DESCRIPTION
## Summary
- ensure websocket client is established before sending binary data
- add null check for binary payload to avoid NPE

## Testing
- `mvn -q -pl spring-ai-alibaba-core test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e73a01e4833096a876ad06ea13a8