### PR TITLE
feat(core): allow custom observation convention

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/tool/ObservableToolCallingManager.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/tool/ObservableToolCallingManager.java
@@ -83,21 +83,31 @@ public class ObservableToolCallingManager implements ToolCallingManager {
 
 	private final ToolExecutionExceptionProcessor toolExecutionExceptionProcessor;
 
-	// TODO Mandatory Convention as ARMS implementation until the Spring AI project
-	// officially supports for observation
-	private final ArmsToolCallingObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
+        // Default ARMS observation convention until the Spring AI project officially
+        // supports observation. Can be overridden via the builder.
+        private final ArmsToolCallingObservationConvention observationConvention;
 
-	public ObservableToolCallingManager(ObservationRegistry observationRegistry,
-			ToolCallbackResolver toolCallbackResolver,
-			ToolExecutionExceptionProcessor toolExecutionExceptionProcessor) {
-		Assert.notNull(observationRegistry, "observationRegistry cannot be null");
-		Assert.notNull(toolCallbackResolver, "toolCallbackResolver cannot be null");
-		Assert.notNull(toolExecutionExceptionProcessor, "toolCallExceptionConverter cannot be null");
+        public ObservableToolCallingManager(ObservationRegistry observationRegistry,
+                        ToolCallbackResolver toolCallbackResolver,
+                        ToolExecutionExceptionProcessor toolExecutionExceptionProcessor) {
+                this(observationRegistry, toolCallbackResolver, toolExecutionExceptionProcessor,
+                                DEFAULT_OBSERVATION_CONVENTION);
+        }
 
-		this.observationRegistry = observationRegistry;
-		this.toolCallbackResolver = toolCallbackResolver;
-		this.toolExecutionExceptionProcessor = toolExecutionExceptionProcessor;
-	}
+        public ObservableToolCallingManager(ObservationRegistry observationRegistry,
+                        ToolCallbackResolver toolCallbackResolver,
+                        ToolExecutionExceptionProcessor toolExecutionExceptionProcessor,
+                        ArmsToolCallingObservationConvention observationConvention) {
+                Assert.notNull(observationRegistry, "observationRegistry cannot be null");
+                Assert.notNull(toolCallbackResolver, "toolCallbackResolver cannot be null");
+                Assert.notNull(toolExecutionExceptionProcessor, "toolCallExceptionConverter cannot be null");
+                Assert.notNull(observationConvention, "observationConvention cannot be null");
+
+                this.observationRegistry = observationRegistry;
+                this.toolCallbackResolver = toolCallbackResolver;
+                this.toolExecutionExceptionProcessor = toolExecutionExceptionProcessor;
+                this.observationConvention = observationConvention;
+        }
 
 	@Override
 	public List<ToolDefinition> resolveToolDefinitions(ToolCallingChatOptions chatOptions) {
@@ -304,7 +314,9 @@ public class ObservableToolCallingManager implements ToolCallingManager {
 
 		private ToolCallbackResolver toolCallbackResolver = DEFAULT_TOOL_CALLBACK_RESOLVER;
 
-		private ToolExecutionExceptionProcessor toolExecutionExceptionProcessor = DEFAULT_TOOL_EXECUTION_EXCEPTION_PROCESSOR;
+                private ToolExecutionExceptionProcessor toolExecutionExceptionProcessor = DEFAULT_TOOL_EXECUTION_EXCEPTION_PROCESSOR;
+
+                private ArmsToolCallingObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
 
 		private Builder() {
 		}
@@ -319,16 +331,22 @@ public class ObservableToolCallingManager implements ToolCallingManager {
 			return this;
 		}
 
-		public ObservableToolCallingManager.Builder toolExecutionExceptionProcessor(
-				ToolExecutionExceptionProcessor toolExecutionExceptionProcessor) {
-			this.toolExecutionExceptionProcessor = toolExecutionExceptionProcessor;
-			return this;
-		}
+                public ObservableToolCallingManager.Builder toolExecutionExceptionProcessor(
+                                ToolExecutionExceptionProcessor toolExecutionExceptionProcessor) {
+                        this.toolExecutionExceptionProcessor = toolExecutionExceptionProcessor;
+                        return this;
+                }
 
-		public ObservableToolCallingManager build() {
-			return new ObservableToolCallingManager(observationRegistry, toolCallbackResolver,
-					toolExecutionExceptionProcessor);
-		}
+                public ObservableToolCallingManager.Builder observationConvention(
+                                ArmsToolCallingObservationConvention observationConvention) {
+                        this.observationConvention = observationConvention;
+                        return this;
+                }
+
+                public ObservableToolCallingManager build() {
+                        return new ObservableToolCallingManager(observationRegistry, toolCallbackResolver,
+                                        toolExecutionExceptionProcessor, observationConvention);
+                }
 
 	}
 

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/tool/ObservableToolCallingManagerTests.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/tool/ObservableToolCallingManagerTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.tool;
+
+import com.alibaba.cloud.ai.tool.observation.ArmsToolCallingObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ObservableToolCallingManager}.
+ */
+class ObservableToolCallingManagerTests {
+
+    @Test
+    void builderAllowsCustomObservationConvention() throws Exception {
+        ArmsToolCallingObservationConvention custom = new ArmsToolCallingObservationConvention() {
+            @Override
+            public String getName() {
+                return "custom";
+            }
+        };
+
+        ObservableToolCallingManager manager = ObservableToolCallingManager.builder()
+                .observationRegistry(ObservationRegistry.NOOP)
+                .observationConvention(custom)
+                .build();
+
+        Field field = ObservableToolCallingManager.class.getDeclaredField("observationConvention");
+        field.setAccessible(true);
+        Object value = field.get(manager);
+
+        assertThat(value).isSameAs(custom);
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring a custom `ArmsToolCallingObservationConvention` via `ObservableToolCallingManager` builder
- add unit test for builder customization

## Testing
- `mvn -q -pl spring-ai-alibaba-core -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b97e0d40a083308cd5f4cc14cdf83c