### PR TITLE
refactor: improve date parsing error handling

### DIFF
--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/utils/common/DateUtils.java
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/utils/common/DateUtils.java
@@ -25,12 +25,17 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Utility class for date and time operations.
  *
  * @since 1.0.0.3
  */
 public class DateUtils extends org.apache.commons.lang3.time.DateUtils {
+
+        private static final Logger logger = LoggerFactory.getLogger(DateUtils.class);
 
 	// Date format patterns
 	public static final String DATE_JFP_STR = "yyyyMM";
@@ -206,18 +211,16 @@ public class DateUtils extends org.apache.commons.lang3.time.DateUtils {
 	/**
 	 * Parse date string in EEE MMM dd HH:mm:ss zzz yyyy format
 	 */
-	public static Date parseDateString(String time) {
-		SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH);
-		Date d = new Date();
-		try {
-			d = sdf.parse(time);
-		}
-		catch (ParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return d;
-	}
+        public static Date parseDateString(String time) {
+                SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH);
+                try {
+                        return sdf.parse(time);
+                }
+                catch (ParseException e) {
+                        logger.warn("Failed to parse date string: {}", time, e);
+                        return null;
+                }
+        }
 
 	/**
 	 * Calculate days between now and given date

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-core/src/test/java/com/alibaba/cloud/ai/studio/core/utils/common/DateUtilsTests.java
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-core/src/test/java/com/alibaba/cloud/ai/studio/core/utils/common/DateUtilsTests.java
@@ -1,0 +1,27 @@
+package com.alibaba.cloud.ai.studio.core.utils.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DateUtils}.
+ */
+class DateUtilsTests {
+
+    @Test
+    void parseDateStringReturnsDateWhenFormatMatches() throws Exception {
+        String time = "Wed Sep 11 12:00:00 GMT 2024";
+        Date expected = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH).parse(time);
+        assertThat(DateUtils.parseDateString(time)).isEqualTo(expected);
+    }
+
+    @Test
+    void parseDateStringReturnsNullOnParseFailure() {
+        assertThat(DateUtils.parseDateString("invalid-date")).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- use slf4j logging and return `null` when date string parsing fails
- add unit tests for `DateUtils.parseDateString`

## Testing
- `mvn -q -pl spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-core -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f7ce61908330a6a1b91c5434f8ec